### PR TITLE
#3 replace call to 819⌶ with ⎕C

### DIFF
--- a/APLX.dyalog
+++ b/APLX.dyalog
@@ -522,6 +522,6 @@
     ⍝ Things to watch for:
     ⍝ ⎕CLASSES is (⎕nl-9.4 9.6)
 
-    L←819⌶ ⍝ Lowercase
+    L←⎕C ⍝ Lowercase
 
 :EndNameSpace


### PR DESCRIPTION
The function `L` converts to lower case.  Rather than using `819⌶` should use `⎕C`.